### PR TITLE
isucon14: Ubuntu Base を 24.04.1 から 24.04.4 に更新

### DIFF
--- a/isucon14/build.ps1
+++ b/isucon14/build.ps1
@@ -5,9 +5,9 @@ Param(
 
 $ErrorActionPreference = "Stop"
 
-#$uri = "http://cdimage.ubuntu.com/ubuntu-base/releases/24.04/release/ubuntu-base-24.04.1-base-amd64.tar.gz"
-$uri = "http://ftp.jaist.ac.jp/pub/Linux/ubuntu-cdimage/ubuntu-base/releases/24.04/release/ubuntu-base-24.04.1-base-amd64.tar.gz"
-$sha256sum = "5B0FFB1E31D4B85F5A2214F105D1377BA616C453B38FF46C278DC6472B21E2D8"
+#$uri = "http://cdimage.ubuntu.com/ubuntu-base/releases/24.04/release/ubuntu-base-24.04.4-base-amd64.tar.gz"
+$uri = "http://ftp.jaist.ac.jp/pub/Linux/ubuntu-cdimage/ubuntu-base/releases/24.04/release/ubuntu-base-24.04.4-base-amd64.tar.gz"
+$sha256sum = "C1E67EF7B17A6300E136118BD1DC04725009CB376C1AAD10ABCF8CD453628D58"
 $tarball = Join-Path $PSScriptRoot ([System.IO.Path]::GetFileName($uri))
 
 If (![System.IO.File]::Exists($tarball)) {


### PR DESCRIPTION
## 問題

`isucon14/build.ps1` が pin している `ubuntu-base-24.04.1-base-amd64.tar.gz` が Ubuntu のミラーから削除されており、環境構築が 404 で失敗します。

```
Invoke-WebRequest : The requested URL was not found on this server.
Apache/2.4.61 (Unix) OpenSSL/3.0.13 Server at ftp.jaist.ac.jp Port 80
At C:\Users\...\wsl-isucon\isucon14\build.ps1:14 char:3
+   Invoke-WebRequest -Uri $uri -OutFile $tarball
```

JAIST ミラーだけでなく本家 cdimage でも 404 で、24.04 の release ディレクトリに現存するのは **24.04.3 と 24.04.4** のみです。

| URL | 結果 |
|---|---|
| jaist … ubuntu-base-24.04.1-base-amd64.tar.gz | **404** |
| cdimage … ubuntu-base-24.04.1-base-amd64.tar.gz | **404** |
| jaist … ubuntu-base-24.04.4-base-amd64.tar.gz | 200 |

## 変更

`isucon14/build.ps1` の URL(コメント側の cdimage 行も含む)と `$sha256sum` を 24.04.4 に更新しました。

sha256sum は **cdimage.ubuntu.com と ftp.jaist.ac.jp 双方の `SHA256SUMS` が同一の値を公開していること**を確認した上で差し替えています。

```
c1e67ef7b17a6300e136118bd1dc04725009cb376c1aad10abcf8cd453628d58 *ubuntu-base-24.04.4-base-amd64.tar.gz
```

## 影響範囲

他の回は影響を受けていません(念のため全 `build.ps1` の URL を確認しました)。

| ディレクトリ | pin | 状態 |
|---|---|---|
| isucon12-qualify / isucon12-final | 22.04 | 200 |
| isucon13 | 22.04.3 | 200 |
| **isucon14** | **24.04.1** | **404 → 本 PR で修正** |

## 動作確認

WSL2(Windows 11)上で、パッチ後の `build.ps1 isucon14` がチェックサム検証を通過し、ディストリの import とセットアップスクリプトの実行まで進むことを確認しました。

## 補足

24.04 の release ディレクトリは最新のポイントリリースのみを残す運用のようなので、24.04.5 が出た時点で同じ問題が再発します。もし恒久対応をご希望であれば、同ディレクトリの `SHA256SUMS` を取得して現行のファイル名とハッシュを解決する形にもできますので、お気軽にお申し付けください(本 PR は既存の方針に合わせて最小限の更新に留めています)。