### PR TITLE
provisioning スクリプトを stdin ではなくファイルから実行し、pnpm を 9 に固定

### DIFF
--- a/isucon12-final/build.ps1
+++ b/isucon12-final/build.ps1
@@ -27,7 +27,15 @@ wsl.exe -t $Distro
 
 $scriptsdir = Join-Path $PSScriptRoot "scripts"
 Get-ChildItem $scriptsdir -Filter *.sh | Sort-Object -Property FullName | Foreach-Object {
-  (Get-Content $_.FullName) -join "`n" | wsl.exe -d $Distro /bin/bash -l
+  # Copy the script into the distro and run it from a file rather than piping it
+  # to bash's stdin: any command in the script that reads stdin (npm, apt, ...)
+  # otherwise swallows the rest of the script, so the remaining steps are
+  # skipped silently.
+  (Get-Content $_.FullName) -join "`n" | wsl.exe -d $Distro /bin/bash -c "cat > /root/provision.sh"
+  If ($LASTEXITCODE -ne 0) { Write-Error "Failed to copy $($_.Name) into $Distro." }
+  wsl.exe -d $Distro /bin/bash -l /root/provision.sh
+  If ($LASTEXITCODE -ne 0) { Write-Error "$($_.Name) failed with exit code $LASTEXITCODE." }
+  wsl.exe -d $Distro rm -f /root/provision.sh
 }
 
 wsl.exe -t $Distro

--- a/isucon12-qualify/build.ps1
+++ b/isucon12-qualify/build.ps1
@@ -27,7 +27,15 @@ wsl.exe -t $Distro
 
 $scriptsdir = Join-Path $PSScriptRoot "scripts"
 Get-ChildItem $scriptsdir -Filter *.sh | Sort-Object -Property FullName | Foreach-Object {
-  (Get-Content $_.FullName) -join "`n" | wsl.exe -d $Distro /bin/bash -l
+  # Copy the script into the distro and run it from a file rather than piping it
+  # to bash's stdin: any command in the script that reads stdin (npm, apt, ...)
+  # otherwise swallows the rest of the script, so the remaining steps are
+  # skipped silently.
+  (Get-Content $_.FullName) -join "`n" | wsl.exe -d $Distro /bin/bash -c "cat > /root/provision.sh"
+  If ($LASTEXITCODE -ne 0) { Write-Error "Failed to copy $($_.Name) into $Distro." }
+  wsl.exe -d $Distro /bin/bash -l /root/provision.sh
+  If ($LASTEXITCODE -ne 0) { Write-Error "$($_.Name) failed with exit code $LASTEXITCODE." }
+  wsl.exe -d $Distro rm -f /root/provision.sh
 }
 
 wsl.exe -t $Distro

--- a/isucon13/build.ps1
+++ b/isucon13/build.ps1
@@ -27,7 +27,15 @@ wsl.exe -t $Distro
 
 $scriptsdir = Join-Path $PSScriptRoot "scripts"
 Get-ChildItem $scriptsdir -Filter *.sh | Sort-Object -Property FullName | Foreach-Object {
-  (Get-Content $_.FullName) -join "`n" | wsl.exe -d $Distro /bin/bash -l
+  # Copy the script into the distro and run it from a file rather than piping it
+  # to bash's stdin: any command in the script that reads stdin (npm, apt, ...)
+  # otherwise swallows the rest of the script, so the remaining steps are
+  # skipped silently.
+  (Get-Content $_.FullName) -join "`n" | wsl.exe -d $Distro /bin/bash -c "cat > /root/provision.sh"
+  If ($LASTEXITCODE -ne 0) { Write-Error "Failed to copy $($_.Name) into $Distro." }
+  wsl.exe -d $Distro /bin/bash -l /root/provision.sh
+  If ($LASTEXITCODE -ne 0) { Write-Error "$($_.Name) failed with exit code $LASTEXITCODE." }
+  wsl.exe -d $Distro rm -f /root/provision.sh
 }
 
 wsl.exe -t $Distro

--- a/isucon14/build.ps1
+++ b/isucon14/build.ps1
@@ -27,7 +27,15 @@ wsl.exe -t $Distro
 
 $scriptsdir = Join-Path $PSScriptRoot "scripts"
 Get-ChildItem $scriptsdir -Filter *.sh | Sort-Object -Property FullName | Foreach-Object {
-  (Get-Content $_.FullName) -join "`n" | wsl.exe -d $Distro /bin/bash -l
+  # Copy the script into the distro and run it from a file rather than piping it
+  # to bash's stdin: any command in the script that reads stdin (npm, apt, ...)
+  # otherwise swallows the rest of the script, so the remaining steps are
+  # skipped silently.
+  (Get-Content $_.FullName) -join "`n" | wsl.exe -d $Distro /bin/bash -c "cat > /root/provision.sh"
+  If ($LASTEXITCODE -ne 0) { Write-Error "Failed to copy $($_.Name) into $Distro." }
+  wsl.exe -d $Distro /bin/bash -l /root/provision.sh
+  If ($LASTEXITCODE -ne 0) { Write-Error "$($_.Name) failed with exit code $LASTEXITCODE." }
+  wsl.exe -d $Distro rm -f /root/provision.sh
 }
 
 wsl.exe -t $Distro

--- a/isucon14/scripts/01-provisioning.sh
+++ b/isucon14/scripts/01-provisioning.sh
@@ -9,7 +9,9 @@ export DEBIAN_FRONTEND=noninteractive
 apt-get install -y --no-install-recommends ansible apt-utils curl make sudo
 snap install go --classic
 snap install node --classic
-npm install -g pnpm
+# pnpm >=10 turns ignored build scripts into a hard error, and isucon14's
+# frontend needs @swc/core and esbuild to run theirs.
+npm install -g pnpm@9
 
 rm -rf ${GITDIR}
 git clone --depth=1 https://github.com/isucon/isucon14.git ${GITDIR}


### PR DESCRIPTION
WSL2 上で isucon14 環境を構築しようとしたところ、**ディストリは作成されるがアプリが一切配置されない**状態になりました。原因が 2 つあったので分けて報告します。#9(Ubuntu Base の URL 404)とは独立した内容です。

---

## 1. スクリプトを stdin にパイプすると途中で打ち切られる(全ディレクトリ)

`build.ps1` はスクリプト本文を bash の標準入力へ渡しています。

```powershell
(Get-Content $_.FullName) -join "`n" | wsl.exe -d $Distro /bin/bash -l
```

このため、スクリプト中に**標準入力を読むコマンド**があると、そのコマンドが**残りのスクリプト本文を読み取ってしまい**、以降の行が実行されないまま bash が正常終了します。`set -e` があってもエラーにはならないため、`build.ps1` は成功したように見えます。

### 最小の再現

```bash
printf '%s\n' 'echo MARKER-1' 'cat > /dev/null' 'echo MARKER-2' > demo.sh

cat demo.sh | bash -l        # → MARKER-1 のみ
bash -l demo.sh < /dev/null  # → MARKER-1 と MARKER-2
```

### 実際に遭遇した症状

isucon14 で `npm install -g pnpm` の直後に打ち切られ、`git clone` 以降(**ansible によるアプリ配置を含む全て**)が実行されないまま「完了」と表示されました。

確認できた状態:
- ログが npm の出力で途切れ、`set -x` のトレースに `+ git clone` が現れない
- スクリプト末尾で削除されるはずの go / node の snap が**残存**
- `isucon` ユーザーが**存在しない**
- `/tmp/isucon14` が**clone されていない**

同じスクリプトをファイルから実行すると、この位置を通過して先へ進みました。

### 変更

スクリプトを一旦ディストリ内へ書き出してから**ファイルとして実行**します。CRLF を LF へ正規化する既存の挙動(`-join "`n"`)はそのまま維持しています。

あわせて、**終了コードを確認**するようにしました。現在は `$LASTEXITCODE` を見ていないため、スクリプトが失敗しても `build.ps1` は成功として進みます(今回の件が静かに成功扱いになった一因です)。

この箇所は 4 ディレクトリすべてで同一のため、まとめて修正しています。

---

## 2. isucon14: pnpm 10 以降でフロントエンドのビルドが失敗する

`npm install -g pnpm` は最新版(現在 11.20.0)を入れますが、**pnpm 10 以降は依存パッケージのビルドスクリプトを既定で実行せず、警告ではなくエラーで停止**します。

```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: @swc/core@1.7.26, esbuild@0.17.6, esbuild@0.21.5
Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.
make: *** [Makefile:6: deps] Error 1
```

isucon14 のフロントエンドは `@swc/core` と `esbuild` の postinstall が走る前提のため、`pnpm@9` を指定するようにしました。

なお 1 の不具合が 2 を覆い隠していました(stdin で打ち切られるため、そもそもフロントエンドのビルドに到達しない)。

---

## 動作確認

Windows 11 / WSL2 上で、2 の修正を入れた `01-provisioning.sh` をファイルから実行し、フロントエンドと bench のビルドを通過して ansible の playbook まで到達、`isucon` ユーザーの作成を確認しました。

1 については上記の最小再現で挙動を確認しています(既存のディストリを壊さずに検証したかったため、`build.ps1` 全体の再実行は行っていません)。もし修正方針が異なる方がよければ、遠慮なくお知らせください。

## 補足

`pnpm@9` の固定はいずれ古くなるので、恒久的には `pnpm install --allow-build=@swc/core,esbuild`(pnpm 10.4+)へ寄せる手もあります。ただし isucon14 側の Makefile に手を入れる必要があるため、本 PR では影響の小さいバージョン固定に留めました。